### PR TITLE
Update syntax of json configuration feature

### DIFF
--- a/JsonPreprocessor/CJsonPreprocessor.py
+++ b/JsonPreprocessor/CJsonPreprocessor.py
@@ -615,6 +615,8 @@ class CJsonPreprocessor():
         for line in sJsonData.splitlines():
             if re.search("\${.+}", line):
                 items = re.split("\s*:\s*", line)
+                if re.match("^\s*\${.+", items[0]):
+                    items[0] = '"' + items[0].strip() + '"'
                 newLine = ""
                 i=0
                 for item in items:


### PR DESCRIPTION
Hello Thomas,

     I created this small change for the corner case below during implementing selftest:   
    ${preprocessor}['definitions']['preproStructure'][${params}['glo']['globalStructure']['general']]: 0.92

     For now both cases below are working:
           - "${preprocessor}['definitions']['preproStructure'][${params}['glo']['globalStructure']['general']]": 0.92
           - ${preprocessor}['definitions']['preproStructure'][${params}['glo']['globalStructure']['general']]: 0.92

Thank you,
Son