### PR TITLE
fix document generation issue due to redundant leading space in section header

### DIFF
--- a/packagedoc/additional_docs/Description.rst
+++ b/packagedoc/additional_docs/Description.rst
@@ -229,8 +229,8 @@ After all imports are resolved by the JsonPreprocessor, this is the resulting of
            "device" : "device_name"
          }
 
- Add new or overwrites existing parameters
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Add new or overwrites existing parameters
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This JsonPreprocessor package also provides developers ability to add new as well as overwrite  
 existing parameters. Developers can update parameters which are already declared and add new 


### PR DESCRIPTION
Hi,

I found that root cause of #36 after tracing the document changes.
The issue comes from the redundant leading space in section header.

I works fine again when I try to build manually.

Thank you,
Ngoan