### PR TITLE
initial workflow to publish package to pypi

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,39 +1,65 @@
-# This workflow will upload a Python Package using Twine when a release is created
-# For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
-
-# This workflow uses actions that are not certified by GitHub.
-# They are provided by a third-party and are governed by
-# separate terms of service, privacy policy, and support
-# documentation.
-
-name: Upload Python Package
+name: Publish JsonPreprocessor to PyPI
 
 on:
-  release:
-    types: [published]
-
-permissions:
-  contents: read
+  push:
+    tags:
+      - "rel/*.*.*"
+      - "rel/*.*.*.*"
 
 jobs:
-  deploy:
+  build-n-publish:
+      name: Build and publish to PyPI
+      runs-on: ubuntu-latest
 
-    runs-on: ubuntu-latest
+      steps:
+        - name: Checkout source
+          uses: actions/checkout@v2
 
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python
-      uses: actions/setup-python@v3
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build
-    - name: Build package
-      run: python -m build
-    - name: Publish package
-      uses: pypa/gh-action-pypi-publish@27b31702a0e7fc50959f5ad993c78deac1bdfc29
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}
+        - name: Set up Python
+          uses: actions/setup-python@v4.3.0
+          with:
+            python-version: "3.9"
+
+        - name: Install dependencies
+          run: |
+            sudo apt-get install -y pandoc
+            sudo apt-get install -y texlive-latex-*
+            python -m pip install --upgrade build twine colorama pypandoc wheel dotdict GenPackageDoc PythonExtensionsCollection
+
+        - name: Build source and wheel distributions
+          run: |
+            python setup.py sdist bdist_wheel
+            twine check --strict dist/*
+
+        - name: Publish distribution to PyPI
+          uses: pypa/gh-action-pypi-publish@release/v1
+          with:
+            password: ${{ secrets.PYPI_API_TOKEN }} # This token should be created in Settings > Secrets > Actions
+            # repository_url: https://test.pypi.org/legacy/ # Use this for testing to upload the distribution to test.pypi
+
+        - name: Create GitHub Release
+          id: create_release
+          uses: actions/create-release@v1.1.4
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+          with:
+            tag_name: ${{ github.ref }}
+            release_name: ${{ github.ref }}
+            draft: false
+            prerelease: false
+
+        - name: Get Asset name
+          run: |
+            export PKG=$(ls dist/ | grep tar)
+            set -- $PKG
+            echo "name=$1" >> $GITHUB_ENV
+        - name: Upload Release Asset (sdist) to GitHub
+          id: upload-release-asset
+          uses: actions/upload-release-asset@v1.0.2
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            upload_url: ${{ steps.create_release.outputs.upload_url }}
+            asset_path: dist/${{ env.name }}
+            asset_name: ${{ env.name }}
+            asset_content_type: application/zip


### PR DESCRIPTION
Hi Thomas,

Please reuse the workflow configuration from Genpackage repo as below merged PR:
https://github.com/test-fullautomation/python-genpackagedoc/pull/32

We only need to adapt the package name and the package dependencies in **Install dependencies** step.
I have done it in this PR.
From your side, the **PYPI_API_TOKEN** should be added in this repo for pypi authentication.

Thank you,
Ngoan
