### PR TITLE
Added some JSONP self test files (for tests of dynamic import)

### DIFF
--- a/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.jsonp
@@ -1,0 +1,17 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level" : "DD"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.R.D.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.R.D.jsonp
@@ -1,0 +1,18 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "CC",
+   "[import]" : "./${DD}/imported.${DD}.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.R.F.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.R.F.jsonp
@@ -1,0 +1,18 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "CC",
+   "[import]" : "./DD/imported.DD.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.jsonp
@@ -1,0 +1,17 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level" : "CC"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/imported.BB.R.D.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/imported.BB.R.D.jsonp
@@ -1,0 +1,18 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "BB",
+   "[import]" : "./${CC}/imported.${CC}.R.D.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/imported.BB.R.F.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/imported.BB.R.F.jsonp
@@ -1,0 +1,18 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "BB",
+   "[import]" : "./CC/imported.CC.R.F.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/imported.BB.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/imported.BB.jsonp
@@ -1,0 +1,17 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level" : "BB"
+}

--- a/test/testfiles/dynamic_imports/AA/imported.AA.R.D.jsonp
+++ b/test/testfiles/dynamic_imports/AA/imported.AA.R.D.jsonp
@@ -1,0 +1,18 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "AA",
+   "[import]" : "./${BB}/imported.${BB}.R.D.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/imported.AA.R.F.jsonp
+++ b/test/testfiles/dynamic_imports/AA/imported.AA.R.F.jsonp
@@ -1,0 +1,18 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "AA",
+   "[import]" : "./BB/imported.BB.R.F.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/imported.AA.jsonp
+++ b/test/testfiles/dynamic_imports/AA/imported.AA.jsonp
@@ -1,0 +1,17 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level" : "AA"
+}

--- a/test/testfiles/dynamic_imports/dynamic_import.R.D.jsonp
+++ b/test/testfiles/dynamic_imports/dynamic_import.R.D.jsonp
@@ -1,0 +1,19 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "[import]" : "./global_defs/global_defs_1.jsonp",
+   "level"    : "dynamic_imports",
+   "[import]" : "./${AA}/imported.${AA}.R.D.jsonp"
+}

--- a/test/testfiles/dynamic_imports/dynamic_import.R.F.jsonp
+++ b/test/testfiles/dynamic_imports/dynamic_import.R.F.jsonp
@@ -1,0 +1,18 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "dynamic_imports",
+   "[import]" : "./AA/imported.AA.R.F.jsonp"
+}

--- a/test/testfiles/dynamic_imports/dynamic_import.jsonp
+++ b/test/testfiles/dynamic_imports/dynamic_import.jsonp
@@ -1,0 +1,17 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level" : "dynamic_imports"
+}

--- a/test/testfiles/dynamic_imports/global_defs/global_defs_1.jsonp
+++ b/test/testfiles/dynamic_imports/global_defs/global_defs_1.jsonp
@@ -1,0 +1,20 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+    "AA" : "AA",
+    "BB" : "BB",
+    "CC" : "CC",
+    "DD" : "DD"
+}

--- a/test/testfiles/dynamic_imports/global_defs/global_defs_2.jsonp
+++ b/test/testfiles/dynamic_imports/global_defs/global_defs_2.jsonp
@@ -1,0 +1,18 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+    "dictDirs" : {"AA" : "AA", "BB" : "BB", "CC" : "CC", "DD" : "DD"},
+    "listDirs" : ["AA", "BB","CC","DD"]
+}


### PR DESCRIPTION
(Corresponding self tests coming soon.)

**Short description:**

* 5 levels of folders and subfolders ('dynamic_imports', 'AA', 'BB', 'CC', 'DD')
* on every level, 3 files:
  - <file_base_name>.jsonp (defining a level indicator key only, no further imports)
  - <file_base_name>.R.D.jsonp (defining a level indicator key and imports recursively another JSONP file using a dynamic path)
  - <file_base_name>.R.F.jsonp (defining a level indicator key and imports recursively another JSONP file using a fix path)
* dynamic_imports\global_defs\global_defs_1.jsonp defines some keys used for dynamic import

**Use case 1 (fix path):**

`"[import]" : "./dynamic_imports/dynamic_import.R.F.jsonp"`

Result (like expected):

`DotDict({'level': 'DD'})`

**Use case 2 (the same like use case 1, but with dynamic paths):**

`"[import]" : "./dynamic_imports/dynamic_import.R.D.jsonp"`

Result:

```
{'AA': 'AA',
 'BB': 'BB',
 'CC': 'CC',
 'DD': 'DD',
 '[import]': '... /dynamic_imports/AA/BB/imported.BB.R.D.jsonp',
 'level': 'AA'}
```

It can be seen that the computation of imports stops at level 'AA'. But also here level 'DD' is expected.

