### PR TITLE
Added further JSONP self test files (for tests of dynamic import)

### DIFF
--- a/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.1.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.1.jsonp
@@ -13,7 +13,5 @@
 //  limitations under the License.
 //**************************************************************************
 {
-   "level"    : "AA",
-   "[import]" : "./BB/imported.BB.R.F.jsonp",
-   "[import]" : "./BB/CC/DD/imported.DD.AA.jsonp"
+   "level" : "DD.1"
 }

--- a/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.2.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.2.jsonp
@@ -13,7 +13,5 @@
 //  limitations under the License.
 //**************************************************************************
 {
-   "level"    : "AA",
-   "[import]" : "./BB/imported.BB.R.F.jsonp",
-   "[import]" : "./BB/CC/DD/imported.DD.AA.jsonp"
+   "level" : "DD.2"
 }

--- a/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.3.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.3.jsonp
@@ -13,7 +13,5 @@
 //  limitations under the License.
 //**************************************************************************
 {
-   "level"    : "AA",
-   "[import]" : "./BB/imported.BB.R.F.jsonp",
-   "[import]" : "./BB/CC/DD/imported.DD.AA.jsonp"
+   "level" : "DD.3"
 }

--- a/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.AA.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.AA.jsonp
@@ -13,7 +13,5 @@
 //  limitations under the License.
 //**************************************************************************
 {
-   "level"    : "AA",
-   "[import]" : "./BB/imported.BB.R.F.jsonp",
-   "[import]" : "./BB/CC/DD/imported.DD.AA.jsonp"
+   "origin" : "DD.AA"
 }

--- a/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.BB.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.BB.jsonp
@@ -13,7 +13,5 @@
 //  limitations under the License.
 //**************************************************************************
 {
-   "level"    : "AA",
-   "[import]" : "./BB/imported.BB.R.F.jsonp",
-   "[import]" : "./BB/CC/DD/imported.DD.AA.jsonp"
+   "origin" : "DD.BB"
 }

--- a/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.CC.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.CC.jsonp
@@ -13,7 +13,5 @@
 //  limitations under the License.
 //**************************************************************************
 {
-   "level"    : "AA",
-   "[import]" : "./BB/imported.BB.R.F.jsonp",
-   "[import]" : "./BB/CC/DD/imported.DD.AA.jsonp"
+   "origin" : "DD.CC"
 }

--- a/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.M.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.M.jsonp
@@ -13,7 +13,6 @@
 //  limitations under the License.
 //**************************************************************************
 {
-   "level"    : "AA",
-   "[import]" : "./BB/imported.BB.R.F.jsonp",
-   "[import]" : "./BB/CC/DD/imported.DD.AA.jsonp"
+   "level"    : "CC",
+   "[import]" : "./DD/imported.DD.3.jsonp",
 }

--- a/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.R.D.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.R.D.jsonp
@@ -14,5 +14,6 @@
 //**************************************************************************
 {
    "level"    : "CC",
-   "[import]" : "./${DD}/imported.${DD}.jsonp"
+   "[import]" : "./${DD}/imported.${DD}.2.jsonp",
+   "[import]" : "./DD/imported.DD.CC.jsonp"
 }

--- a/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.R.F.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.R.F.jsonp
@@ -14,5 +14,6 @@
 //**************************************************************************
 {
    "level"    : "CC",
-   "[import]" : "./DD/imported.DD.jsonp"
+   "[import]" : "./DD/imported.DD.1.jsonp",
+   "[import]" : "./DD/imported.DD.CC.jsonp"
 }

--- a/test/testfiles/dynamic_imports/AA/BB/imported.BB.M.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/imported.BB.M.jsonp
@@ -13,7 +13,6 @@
 //  limitations under the License.
 //**************************************************************************
 {
-   "level"    : "AA",
-   "[import]" : "./BB/imported.BB.R.F.jsonp",
-   "[import]" : "./BB/CC/DD/imported.DD.AA.jsonp"
+   "level"    : "BB",
+   "[import]" : "./${CC}/imported.${CC}.M.jsonp"
 }

--- a/test/testfiles/dynamic_imports/AA/BB/imported.BB.R.D.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/imported.BB.R.D.jsonp
@@ -14,5 +14,6 @@
 //**************************************************************************
 {
    "level"    : "BB",
-   "[import]" : "./${CC}/imported.${CC}.R.D.jsonp"
+   "[import]" : "./${CC}/imported.${CC}.R.D.jsonp",
+   "[import]" : "./CC/DD/imported.DD.BB.jsonp"
 }

--- a/test/testfiles/dynamic_imports/AA/BB/imported.BB.R.F.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/imported.BB.R.F.jsonp
@@ -14,5 +14,6 @@
 //**************************************************************************
 {
    "level"    : "BB",
-   "[import]" : "./CC/imported.CC.R.F.jsonp"
+   "[import]" : "./CC/imported.CC.R.F.jsonp",
+   "[import]" : "./CC/DD/imported.DD.BB.jsonp"
 }

--- a/test/testfiles/dynamic_imports/AA/imported.AA.M.jsonp
+++ b/test/testfiles/dynamic_imports/AA/imported.AA.M.jsonp
@@ -14,6 +14,5 @@
 //**************************************************************************
 {
    "level"    : "AA",
-   "[import]" : "./BB/imported.BB.R.F.jsonp",
-   "[import]" : "./BB/CC/DD/imported.DD.AA.jsonp"
+   "[import]" : "./BB/imported.BB.M.jsonp"
 }

--- a/test/testfiles/dynamic_imports/AA/imported.AA.R.D.jsonp
+++ b/test/testfiles/dynamic_imports/AA/imported.AA.R.D.jsonp
@@ -14,5 +14,6 @@
 //**************************************************************************
 {
    "level"    : "AA",
-   "[import]" : "./${BB}/imported.${BB}.R.D.jsonp"
+   "[import]" : "./${BB}/imported.${BB}.R.D.jsonp",
+   "[import]" : "./BB/CC/DD/imported.DD.AA.jsonp"
 }

--- a/test/testfiles/dynamic_imports/mixed_import.jsonp
+++ b/test/testfiles/dynamic_imports/mixed_import.jsonp
@@ -13,5 +13,9 @@
 //  limitations under the License.
 //**************************************************************************
 {
-   "level" : "DD"
+    "AA" : "AA",
+    "BB" : "BB",
+    "CC" : "CC",
+    "DD" : "DD",
+   "[import]" : "./${AA}/imported.${AA}.M.jsonp"
 }


### PR DESCRIPTION
Test case: `"[import]" : "./dynamic_imports/mixed_import.jsonp"`

A JSONP file (`mixed_import`) imports with a dynamic path another file (`AA`)
that imports with a fix path another file (`BB`)
that imports with a dynamic path another file (`CC`)
that imports with a fix path another file (`DD`)

The computation stops at level '`BB`' and the import of level '`CC`' is not resolved:

 ```
'[import]': '... /dynamic_imports/AA/BB/CC/imported.CC.M.jsonp',
 'level': 'BB'
```

Seems that the problem is caused by a switch from a dynamic path to a fix path.

Expected is level '`DD.3`'
