### PR TITLE
Added further JSONP self test files

### DIFF
--- a/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.P.1.1.1.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.P.1.1.1.jsonp
@@ -1,0 +1,17 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level" : "DD.P.1.1.1"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.P.1.1.2.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.P.1.1.2.jsonp
@@ -1,0 +1,17 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level" : "DD.P.1.1.2"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.P.1.2.1.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.P.1.2.1.jsonp
@@ -1,0 +1,17 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level" : "DD.P.1.2.1"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.P.1.2.2.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.P.1.2.2.jsonp
@@ -1,0 +1,17 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level" : "DD.P.1.2.2"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.P.2.1.1.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.P.2.1.1.jsonp
@@ -1,0 +1,17 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level" : "DD.P.2.1.1"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.P.2.1.2.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.P.2.1.2.jsonp
@@ -1,0 +1,17 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level" : "DD.P.2.1.2"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.P.2.2.1.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.P.2.2.1.jsonp
@@ -1,0 +1,17 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level" : "DD.P.2.2.1"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.P.2.2.2.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/DD/imported.DD.P.2.2.2.jsonp
@@ -1,0 +1,17 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level" : "DD.P.2.2.2"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.P.1.1.1.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.P.1.1.1.jsonp
@@ -1,0 +1,18 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "CC",
+   "[import]" : "./${DD}/imported.${DD}.P.1.1.1.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.P.1.1.2.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.P.1.1.2.jsonp
@@ -1,0 +1,18 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "CC",
+   "[import]" : "./DD/imported.DD.P.1.1.2.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.P.1.2.1.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.P.1.2.1.jsonp
@@ -1,0 +1,18 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "CC",
+   "[import]" : "./${DD}/imported.${DD}.P.1.2.1.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.P.1.2.2.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.P.1.2.2.jsonp
@@ -1,0 +1,18 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "CC",
+   "[import]" : "./DD/imported.DD.P.1.2.2.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.P.2.1.1.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.P.2.1.1.jsonp
@@ -1,0 +1,18 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "CC",
+   "[import]" : "./${DD}/imported.${DD}.P.2.1.1.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.P.2.1.2.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.P.2.1.2.jsonp
@@ -1,0 +1,18 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "CC",
+   "[import]" : "./DD/imported.DD.P.2.1.2.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.P.2.2.1.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.P.2.2.1.jsonp
@@ -1,0 +1,18 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "CC",
+   "[import]" : "./${DD}/imported.${DD}.P.2.2.1.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.P.2.2.2.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/CC/imported.CC.P.2.2.2.jsonp
@@ -1,0 +1,18 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "CC",
+   "[import]" : "./DD/imported.DD.P.2.2.2.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/imported.BB.P.1.1.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/imported.BB.P.1.1.jsonp
@@ -1,0 +1,19 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "BB",
+   "[import]" : "./CC/imported.CC.P.1.1.1.jsonp",
+   "[import]" : "./${CC}/imported.${CC}.P.1.1.2.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/imported.BB.P.1.2.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/imported.BB.P.1.2.jsonp
@@ -1,0 +1,19 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "BB",
+   "[import]" : "./${CC}/imported.${CC}.P.1.2.1.jsonp",
+   "[import]" : "./CC/imported.CC.P.1.2.2.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/imported.BB.P.2.1.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/imported.BB.P.2.1.jsonp
@@ -1,0 +1,19 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "BB",
+   "[import]" : "./${CC}/imported.${CC}.P.2.1.1.jsonp",
+   "[import]" : "./CC/imported.CC.P.2.1.2.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/BB/imported.BB.P.2.2.jsonp
+++ b/test/testfiles/dynamic_imports/AA/BB/imported.BB.P.2.2.jsonp
@@ -1,0 +1,19 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+   "level"    : "BB",
+   "[import]" : "./CC/imported.CC.P.2.2.1.jsonp",
+   "[import]" : "./${CC}/imported.${CC}.P.2.2.2.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/imported.AA.P.1.jsonp
+++ b/test/testfiles/dynamic_imports/AA/imported.AA.P.1.jsonp
@@ -1,0 +1,24 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+    "level"    : "AA",
+    //
+    "BB"       : "BB",
+    "CC"       : "CC",
+    "DD"       : "DD",
+    //
+    "[import]" : "./${BB}/imported.${BB}.P.1.1.jsonp",
+    "[import]" : "./BB/imported.BB.P.1.2.jsonp"
+}

--- a/test/testfiles/dynamic_imports/AA/imported.AA.P.2.jsonp
+++ b/test/testfiles/dynamic_imports/AA/imported.AA.P.2.jsonp
@@ -1,0 +1,24 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+    "level"    : "AA",
+    //
+    "BB"       : "BB",
+    "CC"       : "CC",
+    "DD"       : "DD",
+    //
+    "[import]" : "./BB/imported.BB.P.2.1.jsonp",
+    "[import]" : "./${BB}/imported.${BB}.P.2.2.jsonp"
+}

--- a/test/testfiles/dynamic_imports/parallel_import.jsonp
+++ b/test/testfiles/dynamic_imports/parallel_import.jsonp
@@ -1,0 +1,19 @@
+//  Copyright 2020-2024 Robert Bosch GmbH
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//**************************************************************************
+{
+    "AA"       : "AA",
+    "[import]" : "./${AA}/imported.${AA}.P.1.jsonp",
+    "[import]" : "./${AA}/imported.${AA}.P.2.jsonp"
+}


### PR DESCRIPTION
2 import trees running in parallel

`"[import]" : "./dynamic_imports/parallel_import.jsonp"`

Result:

```
{'AA': 'AA',
 'BB': 'BB',
 'CC': 'CC',
 'DD': 'DD',
 '[import]': '... /dynamic_imports/AA/BB/imported.BB.P.2.2.jsonp',
 'level': 'DD.P.2.1.2'}
```

But expected:
* `'level': 'DD.P.2.2.2'`
* Import of '`imported.BB.P.2.2.jsonp`' resolved

