### PR TITLE
allow to trigger 'Publish JsonPreprocessor to PyPI' workflow manually

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -6,6 +6,11 @@ on:
       - "rel/*.*.*"
       - "rel/*.*.*.*"
   workflow_dispatch:
+    inputs:
+      tag_name:
+        description: 'Release Tag name for creating Github Release'
+        required: false
+        type: string
 
 jobs:
   build-n-publish:
@@ -44,10 +49,29 @@ jobs:
             password: ${{ secrets.PYPI_API_TOKEN }} # This token should be created in Settings > Secrets > Actions
             # repository_url: https://test.pypi.org/legacy/ # Use this for testing to upload the distribution to test.pypi
 
+        - name: Determine tag
+          id: tag
+          run: |
+            TAG_NAME=""
+            if [[ "${{ github.event.inputs.tag_name }}" != "" ]]; then
+              TAG_NAME="${{ github.event.inputs.tag_name }}"
+            elif [[ "${{ github.ref }}" == refs/tags/* ]]; then
+              TAG_NAME="${GITHUB_REF#refs/tags/}"
+            fi
+
+            if [[ -z "$TAG_NAME" ]]; then
+              echo "No valid tag provided. Skipping release."
+              exit 0
+            else
+              echo "TAG_NAME=$TAG_NAME" >> $GITHUB_ENV
+            fi
+
         - name: Create/Update GitHub Release
           id: create_update_release
+          if: env.TAG_NAME != ''
           uses: ncipollo/release-action@v1
           with:
+            tag: ${{ env.TAG_NAME }}
             allowUpdates: true
             omitNameDuringUpdate: true
             makeLatest: true

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - "rel/*.*.*"
       - "rel/*.*.*.*"
+  workflow_dispatch:
 
 jobs:
   build-n-publish:


### PR DESCRIPTION
Hi Thomas,

This PR allow to trigger [Publish JsonPreprocessor to PyPI](https://github.com/test-fullautomation/python-jsonpreprocessor/actions/workflows/python-publish.yml) manually.

Thank you,
Ngoan