### PR TITLE
fix TOC configuration issue when building documentation

### DIFF
--- a/packagedoc/packagedoc_config.json
+++ b/packagedoc/packagedoc_config.json
@@ -57,7 +57,7 @@
    "TOC" : {
             "introduction"   : "./additional_docs/Introduction.tex",
             "description"    : "./additional_docs/Description.tex",
-            "thejsonpformat" : "./additional_docs/The JSONP format.rst",
+            "thejsonpformat" : "./additional_docs/The JSONP format.tex",
             "INTERFACE"      : "../###PACKAGENAME###",
             "appendix"       : "./additional_docs/Appendix.rst",
             "history"        : "./additional_docs/History.tex",


### PR DESCRIPTION
Hi @HolQue ,

I am facing below error when generating documentation for this package
```
Error: !!! ERROR !!!
[CDocBuilder.Build] : File 'C:/GitLab-Runner/builds/EP5Q9gPyB/0/robotframework-aio/main/python-jsonpreprocessor/packagedoc/additional_docs/The JSONP format.rst' does not exist.!
```

I observed that you have changed the TOC configuration from `*.tex` to `*.rst` which causes this error.
https://github.com/test-fullautomation/python-jsonpreprocessor/pull/499/changes#diff-9a6dcff53244c70b45ca2f7485c1038435e6466d7b82dc43230860e52c3b6a71R60

This PR rollback this configuration because only the `The JSONP format.tex` is existing, no `The JSONP format.rst`.
Please correct me if you have also convert to `rst` format but forgot to commit in your previous PR.

Thank you,
Ngoan

